### PR TITLE
Const all the things

### DIFF
--- a/src/HexagoScreenSaver.cpp
+++ b/src/HexagoScreenSaver.cpp
@@ -25,44 +25,40 @@ namespace hexago {
     )
     :
     window(window),
+    window_size(window.getSize()),
     config(config),
+    hexagon_factory(
+        sf::Vector2f(0.0f, 0.0f), // spawn lower bounds
+        sf::Vector2f(window_size), // spawn upper bounds
+        ParameterRange<hexagon_size_t>(
+            window_size.y * this->config.minimum_hexagon_size,
+            window_size.y * this->config.maximum_hexagon_size
+        ),
+        ParameterRange<hexagon_decay_t>(
+            window_size.y * this->config.minimum_hexagon_decay_speed,
+            window_size.y * this->config.maximum_hexagon_decay_speed
+        ),
+        ParameterRange<uint8_t>(
+            this->config.red_colour_channel_minimum,
+            this->config.red_colour_channel_maximum
+        ),
+        ParameterRange<uint8_t>(
+            this->config.green_colour_channel_minimum,
+            this->config.green_colour_channel_maximum
+        ),
+        ParameterRange<uint8_t>(
+            this->config.blue_colour_channel_minimum,
+            this->config.blue_colour_channel_maximum
+        ),
+        ParameterRange<uint8_t>(
+            this->config.alpha_colour_channel_minimum,
+            this->config.alpha_colour_channel_maximum
+        )
+    ),
     hexagon_count(required_number_of_hexagons()) {
-        // get window dimensions
-        sf::Vector2f window_size = sf::Vector2f(this->window.getSize());
-        // instantiate the HexagonFactory with the config settings we've got
-        this->hexagon_factory = HexagonFactory(
-            sf::Vector2f(0.0f, 0.0f), // spawn lower bounds
-            window_size, // spawn upper bounds
-            ParameterRange<hexagon_size_t>(
-                window_size.y * this->config.minimum_hexagon_size,
-                window_size.y * this->config.maximum_hexagon_size
-            ),
-            ParameterRange<hexagon_decay_t>(
-                window_size.y * this->config.minimum_hexagon_decay_speed,
-                window_size.y * this->config.maximum_hexagon_decay_speed
-            ),
-            ParameterRange<uint8_t>(
-                this->config.red_colour_channel_minimum,
-                this->config.red_colour_channel_maximum
-            ),
-            ParameterRange<uint8_t>(
-                this->config.green_colour_channel_minimum,
-                this->config.green_colour_channel_maximum
-            ),
-            ParameterRange<uint8_t>(
-                this->config.blue_colour_channel_minimum,
-                this->config.blue_colour_channel_maximum
-            ),
-            ParameterRange<uint8_t>(
-                this->config.alpha_colour_channel_minimum,
-                this->config.alpha_colour_channel_maximum
-            )
-        );
-        // initialise the hexagons deque to this many elements
-        this->hexagons = std::deque<Hexagon>(this->hexagon_count);
         // populate the array with Hexagon instances from the factory
         for(size_t i = 0; i < this->hexagon_count; i++) {
-            this->hexagons[i] = this->hexagon_factory.next();
+            this->hexagons.push_back(this->hexagon_factory.next());
         }
     }
 
@@ -161,13 +157,12 @@ namespace hexago {
 
     size_t HexagoScreenSaver::required_number_of_hexagons() const {
         // get the screen area first
-        sf::Vector2u screen_size = this->window.getSize();
-        size_t screen_area = screen_size.x * screen_size.y;
+        size_t screen_area = this->window_size.x * this->window_size.y;
         // now get the average hexagon radius
         float average_hexagon_radius = (
-            ((float)screen_size.y * this->config.minimum_hexagon_size)
+            ((float)this->window_size.y * this->config.minimum_hexagon_size)
             +
-            ((float)screen_size.y * this->config.maximum_hexagon_size)
+            ((float)this->window_size.y * this->config.maximum_hexagon_size)
         ) / 2.0f;
         /*
          * the area of a regular hexagon may be found with the side length or 

--- a/src/HexagoScreenSaver.hpp
+++ b/src/HexagoScreenSaver.hpp
@@ -93,6 +93,8 @@ namespace hexago {
              * actual window instance in the scope it was originally declared.
              */
             sf::RenderWindow& window;
+            // store the window's size as we'll use it later on in other places
+            const sf::Vector2u window_size;
             // where we store the config settings
             screen_saver_config_t config;
             // a HexagonFactory instance which will be used to produce Hexagons

--- a/src/Hexagon.cpp
+++ b/src/Hexagon.cpp
@@ -6,9 +6,6 @@
 
 namespace hexago {
 
-    // default constructor, does nothing. Provided as convenience.
-    Hexagon::Hexagon() {}
-
     // constructor
     Hexagon::Hexagon(
         sf::Vector2f centre,

--- a/src/Hexagon.hpp
+++ b/src/Hexagon.hpp
@@ -23,8 +23,6 @@ namespace hexago {
      */
     class Hexagon {
         public:
-            // default constructor, does nothing. Provided as convenience.
-            Hexagon();
             // constructor
             Hexagon(
                 sf::Vector2f centre,

--- a/src/HexagonFactory.cpp
+++ b/src/HexagonFactory.cpp
@@ -6,9 +6,6 @@
 
 namespace hexago {
 
-    // default constructor, does nothing. Provided as convenience.
-    HexagonFactory::HexagonFactory() {}
-
     // constructor
     HexagonFactory::HexagonFactory(
         sf::Vector2f spawn_lower_bound,

--- a/src/HexagonFactory.hpp
+++ b/src/HexagonFactory.hpp
@@ -20,8 +20,6 @@ namespace hexago {
      */
     class HexagonFactory {
         public:
-            // default constructor, does nothing. Provided as convenience.
-            HexagonFactory();
             // constructor
             HexagonFactory(
                 sf::Vector2f spawn_lower_bound,


### PR DESCRIPTION
I went through the codebase and made a load of things that could be `const`, `const`! I did this for methods first, then for some members as well (the compiler wouldn't let me do it to all of them :( )

I also got rid of some lame default constructors that I threw in quickly to get things to work earlier, but which I really didn't want. Re-organising the initialiser lists allowed me to do this.