### PR TITLE
Review: Copy assignment change

### DIFF
--- a/src/HexagoScreenSaver.cpp
+++ b/src/HexagoScreenSaver.cpp
@@ -100,9 +100,16 @@ namespace hexago {
                 if(this->config.spawn_mode == SPAWN_MODE_DEFAULT) {
                     /*
                      * default is to just respawn Hexagons in-place, as far as
-                     * z-indexing is concerned
+                     * z-indexing is concerned. This series of calls:
+                     * 1. Removes the existing Hexagon object
+                     * 2. Inserts a new one from the factory in its place
                      */
-                    this->hexagons[i] = this->hexagon_factory.next();
+                    this->hexagons.insert(
+                        this->hexagons.erase(
+                            this->hexagons.begin() + i
+                        ),
+                        this->hexagon_factory.next()
+                    );
                 } else {
                     /*
                      * for both of the other spawn modes, we remove the dead


### PR DESCRIPTION
I'm not sure about this change.

I thought doing it this way would allow me to have const class members, but it still won't play ball when `start_size` or `decay_rate` are set to `const`...

It seems to still be calling the copy-assignment constructor it auto-generated for the Hexagon class even though here I seem to be trying to explicitly use `std::deque::erase` and `std::deque::insert` to avoid this. Hmmm...