### PR TITLE
Cleanup initializer list styles

### DIFF
--- a/src/HexagoScreenSaver.cpp
+++ b/src/HexagoScreenSaver.cpp
@@ -17,18 +17,19 @@
 namespace hexago {
 
     // simple constructor
-    HexagoScreenSaver::HexagoScreenSaver(
-        sf::RenderWindow& window
-    ) : HexagoScreenSaver(window, default_config()) {}
+    HexagoScreenSaver::HexagoScreenSaver(sf::RenderWindow& window)
+      : HexagoScreenSaver(window, default_config())
+      {}
 
     // customisation constructor
     HexagoScreenSaver::HexagoScreenSaver(
         sf::RenderWindow& window, HexagoScreenSaverConfig config
     )
-    : window(window)
-    , config(config)
-    , hexagon_factory(config, this->window_size(), this->scaling_dimension())
-    , hexagon_count(required_number_of_hexagons()) {
+      : window(window)
+      , config(config)
+      , hexagon_factory(config, this->window_size(), this->scaling_dimension())
+      , hexagon_count(required_number_of_hexagons())
+      {
         // set window framerate to what is given in config
         window.setFramerateLimit(config.framerate);
         // populate the array with Hexagon instances from the factory

--- a/src/HexagoScreenSaverConfig.cpp
+++ b/src/HexagoScreenSaverConfig.cpp
@@ -22,22 +22,22 @@ namespace hexago {
         hexagon_spawn_mode_t spawn_mode,
         background_colour_t background_colour
     )
-    : HexagoScreenSaverConfig(
-        HexagonFactoryConfig(
-            start_size_range,
-            decay_speed_range,
-            colour_model,
-            d_colour_channel_range,
-            e_colour_channel_range,
-            f_colour_channel_range,
-            alpha_colour_channel_range
-        ),
-        framerate,
-        minimum_screen_cover,
-        spawn_mode,
-        background_colour
-    )
-    {}
+      : HexagoScreenSaverConfig(
+            HexagonFactoryConfig(
+                start_size_range,
+                decay_speed_range,
+                colour_model,
+                d_colour_channel_range,
+                e_colour_channel_range,
+                f_colour_channel_range,
+                alpha_colour_channel_range
+            ),
+            framerate,
+            minimum_screen_cover,
+            spawn_mode,
+            background_colour
+        )
+      {}
 
     // delegated constructor
     HexagoScreenSaverConfig::HexagoScreenSaverConfig(
@@ -47,11 +47,11 @@ namespace hexago {
         hexagon_spawn_mode_t spawn_mode,
         background_colour_t background_colour
     )
-    : HexagonFactoryConfig(sub_config)
-    , framerate(framerate)
-    , minimum_screen_cover(minimum_screen_cover)
-    , spawn_mode(spawn_mode)
-    , background_colour(background_colour)
-    {}
+      : HexagonFactoryConfig(sub_config)
+      , framerate(framerate)
+      , minimum_screen_cover(minimum_screen_cover)
+      , spawn_mode(spawn_mode)
+      , background_colour(background_colour)
+      {}
 
 }

--- a/src/Hexagon.cpp
+++ b/src/Hexagon.cpp
@@ -15,11 +15,11 @@ namespace hexago {
         sf::Color colour
         // all the properties are set via an initialiser list
     )
-    : centre(centre)
-    , start_size(start_size)
-    , decay_rate(decay_rate)
-    , colour(colour)
-    {}
+      : centre(centre)
+      , start_size(start_size)
+      , decay_rate(decay_rate)
+      , colour(colour)
+      {}
 
     // returns a SFML shape which can be used to render this hexagon
     sf::CircleShape Hexagon::shape() const {

--- a/src/HexagonFactory.cpp
+++ b/src/HexagonFactory.cpp
@@ -29,32 +29,32 @@ namespace hexago {
      * once for constructing the type
      * second for calling it, as that's what will give us random samples
      */
-    : random_number_engine(std::mt19937(std::random_device()()))
-    , x_spawn_range(0.0f, (float)window_size.x)
-    , y_spawn_range(0.0f, (float)window_size.y)
-    , start_size_range(
-        scaling_dimension / config.start_size_range.min,
-        scaling_dimension / config.start_size_range.max
-    )
-    , decay_speed_range(
-        scaling_dimension / config.decay_speed_range.min,
-        scaling_dimension / config.decay_speed_range.max
-    )
-    , colour_model(config.colour_model)
-    , d_colour_channel_range(
-        config.d_colour_channel_range.min, config.d_colour_channel_range.max
-    )
-    , e_colour_channel_range(
-        config.e_colour_channel_range.min, config.e_colour_channel_range.max
-    )
-    , f_colour_channel_range(
-        config.f_colour_channel_range.min, config.f_colour_channel_range.max
-    )
-    , alpha_colour_channel_range(
-        config.alpha_colour_channel_range.min,
-        config.alpha_colour_channel_range.max
-    )
-    {}
+      : random_number_engine(std::mt19937(std::random_device()()))
+      , x_spawn_range(0.0f, (float)window_size.x)
+      , y_spawn_range(0.0f, (float)window_size.y)
+      , start_size_range(
+          scaling_dimension / config.start_size_range.min,
+          scaling_dimension / config.start_size_range.max
+      )
+      , decay_speed_range(
+          scaling_dimension / config.decay_speed_range.min,
+          scaling_dimension / config.decay_speed_range.max
+      )
+      , colour_model(config.colour_model)
+      , d_colour_channel_range(
+          config.d_colour_channel_range.min, config.d_colour_channel_range.max
+      )
+      , e_colour_channel_range(
+          config.e_colour_channel_range.min, config.e_colour_channel_range.max
+      )
+      , f_colour_channel_range(
+          config.f_colour_channel_range.min, config.f_colour_channel_range.max
+      )
+      , alpha_colour_channel_range(
+          config.alpha_colour_channel_range.min,
+          config.alpha_colour_channel_range.max
+      )
+      {}
 
     // returns a randomly-generated Hexagon instance from the factory
     Hexagon HexagonFactory::next() {

--- a/src/HexagonFactoryConfig.cpp
+++ b/src/HexagonFactoryConfig.cpp
@@ -15,13 +15,13 @@ namespace hexago {
         ParameterRange<colour_channel_t> f_colour_channel_range,
         ParameterRange<colour_channel_t> alpha_colour_channel_range
     )
-    : start_size_range(start_size_range)
-    , decay_speed_range(decay_speed_range)
-    , colour_model(colour_model)
-    , d_colour_channel_range(d_colour_channel_range)
-    , e_colour_channel_range(e_colour_channel_range)
-    , f_colour_channel_range(f_colour_channel_range)
-    , alpha_colour_channel_range(alpha_colour_channel_range)
-    {}
+      : start_size_range(start_size_range)
+      , decay_speed_range(decay_speed_range)
+      , colour_model(colour_model)
+      , d_colour_channel_range(d_colour_channel_range)
+      , e_colour_channel_range(e_colour_channel_range)
+      , f_colour_channel_range(f_colour_channel_range)
+      , alpha_colour_channel_range(alpha_colour_channel_range)
+      {}
 
 }

--- a/src/ParameterRange.inl
+++ b/src/ParameterRange.inl
@@ -12,12 +12,14 @@ namespace hexago {
     // this constructor sets both min and max to the value given
     template<typename type>
     ParameterRange<type>::ParameterRange(type value)
-    : ParameterRange(value, value) {}
+      : ParameterRange(value, value)
+      {}
 
     // this constructor sets min and max to separate respective values
     template<typename type>
     ParameterRange<type>::ParameterRange(type min, type max)
-    : min(min), max(max) {}
+      : min(min), max(max)
+      {}
 
     // this method validates the struct (min <= max)
     template<typename type>


### PR DESCRIPTION
I've decided on this format:

```cpp
    // constructor
    HexagonFactory::HexagonFactory(
        HexagonFactoryConfig& config,
        sf::Vector2u window_size,
        double scaling_dimension
    )
    /*
     * all of the properties are set via an initialiser list, reading from
     * config object. additionally, the window size needs to be known so
     * that the spawn bounds can be configured and the scaling factor needs
     * to be known so that the sizes and speeds may be set relative to this.
     *
     * std::random_device has two parens for a reason:
     * once for constructing the type
     * second for calling it, as that's what will give us random samples
     */
      : random_number_engine(std::mt19937(std::random_device()()))
      , x_spawn_range(0.0f, (float)window_size.x)
      , y_spawn_range(0.0f, (float)window_size.y)
      , start_size_range(
          scaling_dimension / config.start_size_range.min,
          scaling_dimension / config.start_size_range.max
      )
      , decay_speed_range(
          scaling_dimension / config.decay_speed_range.min,
          scaling_dimension / config.decay_speed_range.max
      )
      , colour_model(config.colour_model)
      , d_colour_channel_range(
          config.d_colour_channel_range.min, config.d_colour_channel_range.max
      )
      , e_colour_channel_range(
          config.e_colour_channel_range.min, config.e_colour_channel_range.max
      )
      , f_colour_channel_range(
          config.f_colour_channel_range.min, config.f_colour_channel_range.max
      )
      , alpha_colour_channel_range(
          config.alpha_colour_channel_range.min,
          config.alpha_colour_channel_range.max
      )
      {}
```

Note that the colon and commas are all in the second column after the closing bracket of the function arguments, and the function body opening brace is also in this column.

Closes #45