### PR TITLE
Add sensible colour channel range defaults

### DIFF
--- a/src/ArgumentParser.cpp
+++ b/src/ArgumentParser.cpp
@@ -198,6 +198,8 @@ namespace hexago {
         for(int i = 1; i < argc; i++) {
             i += parse_argument(i, argc, argv, config);
         }
+        // call resolve_defaults() to make config valid
+        config.resolve_defaults();
         return config;
     }
 

--- a/src/HexagoScreenSaver.cpp
+++ b/src/HexagoScreenSaver.cpp
@@ -119,12 +119,13 @@ namespace hexago {
             // decay_speed_range
             ParameterRange<hexagon_decay_t>(32.0, 16.0),
             COLOUR_MODEL_RGB, // colour_model
+            // NOTE: The default "don't care" value for a colour channel is NAN
             // d_colour_channel_range
-            ParameterRange<colour_channel_t>(0.0, 255.0),
+            ParameterRange<colour_channel_t>(NAN, NAN),
             // e_colour_channel_range
-            ParameterRange<colour_channel_t>(0.0, 255.0),
+            ParameterRange<colour_channel_t>(NAN, NAN),
             // f_colour_channel_range
-            ParameterRange<colour_channel_t>(0.0, 255.0),
+            ParameterRange<colour_channel_t>(NAN, NAN),
             // alpha_colour_channel_range
             ParameterRange<colour_channel_t>(100.0, 100.0),
             30, // framerate

--- a/src/HexagonFactory.cpp
+++ b/src/HexagonFactory.cpp
@@ -33,26 +33,26 @@ namespace hexago {
       , x_spawn_range(0.0f, (float)window_size.x)
       , y_spawn_range(0.0f, (float)window_size.y)
       , start_size_range(
-          scaling_dimension / config.start_size_range.min,
-          scaling_dimension / config.start_size_range.max
+        scaling_dimension / config.start_size_range.min,
+        scaling_dimension / config.start_size_range.max
       )
       , decay_speed_range(
-          scaling_dimension / config.decay_speed_range.min,
-          scaling_dimension / config.decay_speed_range.max
+        scaling_dimension / config.decay_speed_range.min,
+        scaling_dimension / config.decay_speed_range.max
       )
       , colour_model(config.colour_model)
       , d_colour_channel_range(
-          config.d_colour_channel_range.min, config.d_colour_channel_range.max
+        config.d_colour_channel_range.min, config.d_colour_channel_range.max
       )
       , e_colour_channel_range(
-          config.e_colour_channel_range.min, config.e_colour_channel_range.max
+        config.e_colour_channel_range.min, config.e_colour_channel_range.max
       )
       , f_colour_channel_range(
-          config.f_colour_channel_range.min, config.f_colour_channel_range.max
+        config.f_colour_channel_range.min, config.f_colour_channel_range.max
       )
       , alpha_colour_channel_range(
-          config.alpha_colour_channel_range.min,
-          config.alpha_colour_channel_range.max
+        config.alpha_colour_channel_range.min,
+        config.alpha_colour_channel_range.max
       )
       {}
 

--- a/src/HexagonFactoryConfig.cpp
+++ b/src/HexagonFactoryConfig.cpp
@@ -1,9 +1,18 @@
+#include <cmath>
+
 #include "ParameterRange.hpp"
 #include "HexagonFactoryConfig.hpp"
 #include "Hexagon.hpp"
 
 
 namespace hexago {
+
+    // sets a given channel value to the value of check if it is NAN
+    static void clamp_if_nan(colour_channel_t& input, colour_channel_t check) {
+        if(std::isnan(input)) {
+            input = check;
+        }
+    }
 
     // constructor
     HexagonFactoryConfig::HexagonFactoryConfig(
@@ -23,5 +32,51 @@ namespace hexago {
       , f_colour_channel_range(f_colour_channel_range)
       , alpha_colour_channel_range(alpha_colour_channel_range)
       {}
+
+    // validates any unresolved members of the config struct (i.e. NANs)
+    void HexagonFactoryConfig::resolve_defaults() {
+        /*
+         * check if any of the colour channel values are NAN, and if they are
+         * then set them to the default value for that channel, according to
+         * which colour model is in use
+         */
+        ParameterRange<colour_channel_t> d_channel_bounds;
+        ParameterRange<colour_channel_t> e_channel_bounds;
+        ParameterRange<colour_channel_t> f_channel_bounds;
+        // check which colour model we're using, set bounds accordingly
+        switch(this->colour_model) {
+            case COLOUR_MODEL_RGB:
+                d_channel_bounds.min = 0;
+                d_channel_bounds.max = 255;
+                e_channel_bounds.min = 0;
+                e_channel_bounds.max = 255;
+                f_channel_bounds.min = 0;
+                f_channel_bounds.max = 255;
+                break;
+            case COLOUR_MODEL_HSV:
+                d_channel_bounds.min = 0;
+                d_channel_bounds.max = 360;
+                e_channel_bounds.min = 0;
+                e_channel_bounds.max = 100;
+                f_channel_bounds.min = 0;
+                f_channel_bounds.max = 100;
+                break;
+            case COLOUR_MODEL_LAB:
+                d_channel_bounds.min = 0;
+                d_channel_bounds.max = 100;
+                e_channel_bounds.min = -100;
+                e_channel_bounds.max = 100;
+                f_channel_bounds.min = -100;
+                f_channel_bounds.max = 100;
+                break;
+        }
+        // check any channel values for NANs and set them to bounds if so
+        clamp_if_nan(this->d_colour_channel_range.min, d_channel_bounds.min);
+        clamp_if_nan(this->d_colour_channel_range.max, d_channel_bounds.max);
+        clamp_if_nan(this->e_colour_channel_range.min, e_channel_bounds.min);
+        clamp_if_nan(this->e_colour_channel_range.max, e_channel_bounds.max);
+        clamp_if_nan(this->f_colour_channel_range.min, f_channel_bounds.min);
+        clamp_if_nan(this->f_colour_channel_range.max, f_channel_bounds.max);
+    }
 
 }

--- a/src/HexagonFactoryConfig.hpp
+++ b/src/HexagonFactoryConfig.hpp
@@ -53,6 +53,9 @@ namespace hexago {
             ParameterRange<colour_channel_t> f_colour_channel_range,
             ParameterRange<colour_channel_t> alpha_colour_channel_range
         );
+
+        // validates any unresolved members of the config struct (i.e. NANs)
+        void resolve_defaults();
     };
 
 }


### PR DESCRIPTION
When no values are given for colour channel ranges, appropriate defaults are now chosen.
This relies on NaN being used as a sentinel value for 'none given, choose default'
Defaults are chosen based on colour model in use.

Closes #50